### PR TITLE
Fix parsing of M3UA User Protocol Data

### DIFF
--- a/m3ua-unbundle.py
+++ b/m3ua-unbundle.py
@@ -226,6 +226,7 @@ def m3ua_header(data):
 
     # handle tags
     data = data[8:]
+    pdata = []
     while True:
         try:
             tag = data[0:2]
@@ -237,13 +238,14 @@ def m3ua_header(data):
             elif tag == ['02','10']:
                 (protocol_hdr, data) = protocol(data[2:])
                 header.update(protocol_hdr)
+                pdata = data
             else:
                 break
         except ValueError:
             break
         except IndexError:
             break
-    return (header, data)
+    return (header, pdata)
 
 def m3ua_to_mtp3(m3ua_header):
     mtp3_header = list()


### PR DESCRIPTION
The test [pcap file](https://drive.google.com/file/d/0B_WGaHAfzdQZYkNsT0MwU3FFY2s/view?usp=sharing) contains one ISUP IAM message on CIC 2

The script fails to convert this message because the CIC (02 00) is the same as Network Appearance tag
